### PR TITLE
Update .gitmodules

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -19,7 +19,7 @@
 	url = https://github.com/NordicSemiconductor/nrfx.git
 [submodule "lib/lv_bindings"]
 	path = lib/lv_bindings
-	url = git@github.com:esixtyone/lv_binding_micropython.git
+	url = https://github.com/esixtyone/lv_binding_micropython.git
 [submodule "lib/mbedtls"]
 	path = lib/mbedtls
 	url = https://github.com/ARMmbed/mbedtls.git


### PR DESCRIPTION
Use https reference so that an ssh key isn't necessary to fetch the `lv_bindings` dependency.